### PR TITLE
Correct repo filter criteria

### DIFF
--- a/.ci-orchestrator/labels.yml
+++ b/.ci-orchestrator/labels.yml
@@ -11,7 +11,7 @@ triggers:
   - property: action
     include: labeled
   - property: repo
-    include: OpenLiberty/for-automation-testing
+    include: for-automation-testing
   - property: labels
     include: "Opened by external contributor"
   - property: labels


### PR DESCRIPTION
The `repo include` needs to shorten to just the repository name without the organization name as precursor.