### PR TITLE
Filter with userExternal = true property

### DIFF
--- a/.ci-orchestrator/labels.yml
+++ b/.ci-orchestrator/labels.yml
@@ -16,6 +16,8 @@ triggers:
     include: "Opened by external contributor"
   - property: labels
     exclude: "test"
+  - property: userExternal
+    include: true
   propertyDefinitions:
     - name: user
       isRequired: true


### PR DESCRIPTION
Test that pipeline triggers only when issue creator is an external user (does not belong to the OpenLiberty or IBM GitHub orgs).